### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy Portfolio to S3
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ dev ]


### PR DESCRIPTION
Potential fix for [https://github.com/disaenz/portfolio-site/security/code-scanning/1](https://github.com/disaenz/portfolio-site/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`, limiting it to read-only access to repository contents. Since the workflow does not require write access to the repository, this is the least privilege configuration.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
