### PR TITLE
Polish portfolio UI and CI quality gates

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: 🚀 CI/CD Pipeline for Portfolio
+name: 🚀 Deploy Portfolio
 
 permissions:
   contents: read
@@ -6,17 +6,14 @@ permissions:
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_dispatch:
 
 concurrency:
   group: portfolio-deploy-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  ci:
-    name: 🛠 CI (Lint & Build)
+  build:
+    name: Build Site
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -31,10 +28,7 @@ jobs:
           echo "VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}" > .env
           echo "Created .env with API Base URL"
 
-      - name: 🛡️ Static code analysis (ESLint)
-        run: npm run lint
-
-      - name: 🔨 Build site
+      - name: Build site
         run: npm run build
 
       - name: Upload build artifact
@@ -45,9 +39,8 @@ jobs:
 
   cd:
     name: 🚀 CD (Deploy to S3 + CloudFront)
-    needs: ci
+    needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     env:
       DOMAIN: "daniel-saenz.com"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: 🛠 CI Checks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: portfolio-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Static code analysis (ESLint)
+        run: npm run lint
+
+  test:
+    name: Unit Tests & Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Inject API environment variable
+        run: |
+          echo "VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}" > .env
+          echo "Created .env with API Base URL"
+
+      - name: Unit tests with coverage
+        run: npm run test:ci
+
+      - name: Generate coverage summary
+        if: always()
+        run: npm run coverage:summary
+
+      - name: Add coverage to job summary
+        if: always()
+        run: cat coverage/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+
+      - name: Upload JUnit test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: junit-test-report
+          path: coverage/junit.xml
+
+  build:
+    name: Build
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Inject API environment variable
+        run: |
+          echo "VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}" > .env
+          echo "Created .env with API Base URL"
+
+      - name: Build site
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
+.vite
+.turbo
 *.local
 
 # Editor directories and files

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository powers my personal portfolio site, featuring:
 * **Landing sections**: About Me, Projects, Experience, Education, and Skills
 * **Projects showcase**: Deep dive projects I've built.
 * **Experience timeline**: Highlights of my DevSecOps and Software Engineering roles
+* **AI assistant**: Bilingual chat experience for questions about my professional background
+* **Scroll polish**: Responsive reveal animations and a subtle scroll progress indicator
 * **Contact section**: Email and social links are provided in Hero page
 
 The site is built with React and Chakra UI, deployed to AWS S3 + CloudFront and GitHub Actions for continuous integration and delivery.
@@ -20,9 +22,11 @@ The site is built with React and Chakra UI, deployed to AWS S3 + CloudFront and 
 ## 🛠 Technologies
 
 * **Frontend**: React, Vite, Chakra UI
+* **Animation**: Framer Motion
+* **Testing**: Vitest, React Testing Library, JSDOM, V8 coverage
 * **CI/CD**: GitHub Actions
 * **Hosting**: AWS S3 (static site), CloudFront (CDN)
-* **Security & Quality**: ESLint, CI checks, CodeQL, automated CloudFront invalidations
+* **Security & Quality**: ESLint, CI checks, test coverage reports, automated CloudFront invalidations
 
 ---
 
@@ -60,6 +64,32 @@ The site is built with React and Chakra UI, deployed to AWS S3 + CloudFront and 
   npm run lint
   ```
 
+* **Run unit tests**
+
+  ```bash
+  npm run test
+  ```
+
+* **Run tests with coverage**
+
+  ```bash
+  npm run test:coverage
+  ```
+
+* **Run the CI test command**
+
+  ```bash
+  npm run test:ci
+  ```
+
+  This generates coverage output plus a JUnit XML report at `coverage/junit.xml`.
+
+* **Generate a local coverage summary**
+
+  ```bash
+  npm run coverage:summary
+  ```
+
 * **Build for production**
 
   ```bash
@@ -76,11 +106,18 @@ The site is built with React and Chakra UI, deployed to AWS S3 + CloudFront and 
 
 ## 🚀 Deployment
 
-This project uses a CI/CD pipeline to deploy automatically when code is pushed to `main`:
+This project separates CI and CD workflows:
 
-1. **Build & Lint**: Runs on GitHub Actions, creates a build artifact
-2. **Deploy to S3**: Syncs `dist/` to the S3 bucket
-3. **Invalidate CloudFront**: Ensures users see the latest content immediately
+* **CI checks** (`.github/workflows/ci.yml`): Runs on pull requests to `main`
+  * `Lint` and `Unit Tests & Coverage` run in parallel
+  * `Build` runs after lint and tests pass
+  * Coverage and JUnit reports are uploaded as GitHub Actions artifacts
+  * Coverage totals are added to the GitHub Actions job summary
+* **CD deploy** (`.github/workflows/cd.yml`): Runs when code is pushed to `main`
+  * Builds the production site
+  * Uploads the `dist/` artifact
+  * Syncs `dist/` to S3
+  * Invalidates CloudFront so users see the latest content immediately
 
 
 ## 📜 Fork & Attribution

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,7 @@ export default defineConfig([
     ignores: [
       "README.md",
       "dist/**",
+      "coverage/**",
       "node_modules/**"
     ],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,17 +24,30 @@
         "@eslint/js": "^9.29.0",
         "@eslint/json": "^0.12.0",
         "@eslint/markdown": "^6.5.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^9.29.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.2.0",
         "js-yaml": "^4.1.1",
-        "vite": "^7.2.6"
+        "jsdom": "^29.1.1",
+        "vite": "^7.2.6",
+        "vitest": "^4.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -49,6 +62,57 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -180,18 +244,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -222,12 +286,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.27.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.27.3"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -319,16 +383,39 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
-      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@chakra-ui/accordion": {
@@ -1588,6 +1675,146 @@
         "react": ">=18"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -2442,6 +2669,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2551,15 +2796,15 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2927,6 +3172,111 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2972,6 +3322,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -2980,6 +3341,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3100,6 +3468,150 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@zag-js/dom-query": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.16.0.tgz",
@@ -3161,6 +3673,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3194,6 +3717,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -3334,6 +3867,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3408,6 +3970,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -3540,6 +4112,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3725,11 +4307,53 @@
         "tiny-invariant": "^1.0.6"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3801,6 +4425,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -3908,6 +4539,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3928,6 +4567,19 @@
       "integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -4052,6 +4704,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4403,6 +5062,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4411,6 +5080,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -4994,6 +5673,26 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -5038,6 +5737,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inline-style-parser": {
@@ -5358,6 +6067,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5517,6 +6233,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -5552,6 +6307,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -5711,6 +6517,68 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-table": {
@@ -6654,6 +7522,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6813,6 +7691,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6936,6 +7828,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6970,6 +7875,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7059,6 +7971,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7271,6 +8221,20 @@
         }
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7379,6 +8343,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -7510,6 +8484,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7676,6 +8663,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -7704,6 +8698,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7831,6 +8839,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7903,11 +8924,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -7926,11 +8971,67 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.5"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -8066,6 +9167,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unified": {
@@ -8342,6 +9453,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8447,6 +9696,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8456,6 +9722,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest --run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest --run --coverage",
+    "test:ci": "vitest --run --coverage --reporter=default --reporter=junit --outputFile.junit=coverage/junit.xml",
+    "coverage:summary": "node scripts/coverage-summary.mjs",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -26,15 +31,21 @@
     "@eslint/js": "^9.29.0",
     "@eslint/json": "^0.12.0",
     "@eslint/markdown": "^6.5.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^9.29.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.2.0",
     "js-yaml": "^4.1.1",
-    "vite": "^7.2.6"
+    "jsdom": "^29.1.1",
+    "vite": "^7.2.6",
+    "vitest": "^4.1.9"
   }
 }

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -1,0 +1,34 @@
+import { readFileSync, writeFileSync } from "node:fs";
+
+const summaryPath = "coverage/coverage-summary.json";
+const outputPath = "coverage/summary.md";
+
+const coverage = JSON.parse(readFileSync(summaryPath, "utf8"));
+const total = coverage.total;
+
+const rows = [
+  ["Lines", total.lines],
+  ["Statements", total.statements],
+  ["Functions", total.functions],
+  ["Branches", total.branches],
+];
+
+const format = ({ pct, covered, total }) =>
+  `${pct.toFixed(2)}% (${covered}/${total})`;
+
+const markdown = [
+  "## Test & Coverage Report",
+  "",
+  "| Metric | Coverage |",
+  "| --- | ---: |",
+  ...rows.map(([label, metric]) => `| ${label} | ${format(metric)} |`),
+  "",
+  "Artifacts include:",
+  "",
+  "- `coverage-report`: HTML and LCOV coverage output",
+  "- `junit-test-report`: JUnit XML test results",
+  "",
+].join("\n");
+
+writeFileSync(outputPath, markdown);
+console.log(markdown);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import Education from "./components/Education.jsx";
 import MediaAndHighlights from "./components/MediaAndHighlights.jsx";
 import ChatBubble from "./components/ChatBubble.jsx";
 import ChatModal from "./components/ChatModal.jsx";
+import ScrollProgress from "./components/ScrollProgress.jsx";
 
 export default function App() {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -31,6 +32,8 @@ export default function App() {
 
   return (
     <Box bg="#1b212d" color="white" minH="100vh">
+      <ScrollProgress />
+
       <Box
         as="main"
         maxW="1200px"

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,49 +1,42 @@
 import React from "react";
 import { Box, Heading, Text, Link } from "@chakra-ui/react";
+import ScrollReveal from "./ScrollReveal.jsx";
 
 export default function About() {
   return (
     <Box as="section" id="about" w="100%" bg="gray.50" py={16} px={{ base: 4, md: 8 }}>
-      <Heading as="h2" size="xl" color="teal.300" textAlign="center" mb={6}>
-        About Me
-      </Heading>
-      <Text fontSize="lg" color="gray.700" maxW="3xl" mx="auto" mb={4}>
-        I’m a Software Engineer & DevSecOps Engineer with over 10 years of
-        experience. I’ve contributed to both client-side and server-side projects, 
-        but I truly excel at crafting and operating scalable back-end systems.
-      </Text>
-      <Text fontSize="lg" color="gray.700" maxW="3xl" mx="auto" mb={4}>
-        I design and maintain CI/CD pipelines that automate builds, perform
-        static code analysis and unit testing, containerize applications,
-        integrate vulnerability scanning, and deliver reliable, successful
-        deployments every time.
-      </Text>
-      <Text fontSize="lg" color="gray.700" maxW="3xl" mx="auto" mb={4}>
-        Over the years I’ve developed full-scale applications and automated
-        deployments for multiple apps. I also led a proof-of-concept to
-        migrate on-premises infrastructure to AWS, Azure, Google Cloud, and
-        Oracle Cloud, ensuring minimal downtime and zero data loss.
-      </Text>
-      <Text fontSize="lg" color="gray.700" maxW="3xl" mx="auto" mb={4}>
-        Technology changes constantly. To keep up with technology, 
-        I quickly acquire proficiency in new languages and frameworks.
-      </Text>
-      <Text fontSize="lg" color="gray.700" maxW="3xl" mx="auto" mb={4}>
-        Beyond work, I love watching baseball and soccer. Rooting for the Dodgers 
-        at Dodger Stadium or watching a high-stakes soccer game, especially if Mexico 
-        or the US is playing. I also cherish family adventures, especially visits to Disneyland 
-        and discovering new corners around the world.
-      </Text>
-      <Box mt={8} textAlign="center">
-        <Link
-          href="https://www.dropbox.com/scl/fi/vr6msczyp321femehlrcg/Daniel-Saenz-Resume.pdf?rlkey=y2zh8uhylud8zgp6dt5jiund6&st=ai7knzyg&dl=0"
-          isExternal
-          color="teal.500"
-          fontWeight="bold"
-        >
-          Download My Resume
-        </Link>
-      </Box>
+      <ScrollReveal>
+        <Heading as="h2" size="xl" color="teal.300" textAlign="center" mb={6}>
+          About Me
+        </Heading>
+      </ScrollReveal>
+
+      {[
+        "I’m a Software Engineer & DevSecOps Engineer with over 10 years of experience. I’ve contributed to both client-side and server-side projects, but I truly excel at crafting and operating scalable back-end systems.",
+        "I design and maintain CI/CD pipelines that automate builds, perform static code analysis and unit testing, containerize applications, integrate vulnerability scanning, and deliver reliable, successful deployments every time.",
+        "Over the years I’ve developed full-scale applications and automated deployments for multiple apps. I also led a proof-of-concept to migrate on-premises infrastructure to AWS, Azure, Google Cloud, and Oracle Cloud, ensuring minimal downtime and zero data loss.",
+        "Technology changes constantly. To keep up with technology, I quickly acquire proficiency in new languages and frameworks.",
+        "Beyond work, I love watching baseball and soccer. Rooting for the Dodgers at Dodger Stadium or watching a high-stakes soccer game, especially if Mexico or the US is playing. I also cherish family adventures, especially visits to Disneyland and discovering new corners around the world.",
+      ].map((copy, index) => (
+        <ScrollReveal key={copy} delay={index * 0.05} distance={22}>
+          <Text fontSize="lg" color="gray.700" maxW="3xl" mx="auto" mb={4}>
+            {copy}
+          </Text>
+        </ScrollReveal>
+      ))}
+
+      <ScrollReveal delay={0.18} distance={20}>
+        <Box mt={8} textAlign="center">
+          <Link
+            href="https://www.dropbox.com/scl/fi/vr6msczyp321femehlrcg/Daniel-Saenz-Resume.pdf?rlkey=y2zh8uhylud8zgp6dt5jiund6&st=ai7knzyg&dl=0"
+            isExternal
+            color="teal.500"
+            fontWeight="bold"
+          >
+            Download My Resume
+          </Link>
+        </Box>
+      </ScrollReveal>
     </Box>
   );
 }

--- a/src/components/ChatBubble.jsx
+++ b/src/components/ChatBubble.jsx
@@ -8,6 +8,7 @@ export default function ChatBubble({ onOpen }) {
     <Tooltip label="Chat with Daniel&apos;s AI" placement="left">
       <IconButton
         icon={<ChatIcon />}
+        aria-label="Chat with Daniel's AI"
         position="fixed"
         bottom="20px"
         right="20px"

--- a/src/components/ChatBubble.test.jsx
+++ b/src/components/ChatBubble.test.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ChatBubble from "./ChatBubble.jsx";
+import { renderWithChakra } from "../test/renderWithChakra.jsx";
+
+describe("ChatBubble", () => {
+  it("opens the chat when clicked", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+
+    renderWithChakra(<ChatBubble onOpen={onOpen} />);
+
+    await user.click(screen.getByRole("button", { name: /chat with daniel's ai/i }));
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ChatModal.jsx
+++ b/src/components/ChatModal.jsx
@@ -145,20 +145,30 @@ export default function ChatModal({ isOpen, onClose }) {
       isOpen={isOpen}
       onClose={onClose}
       size={{ base: "full", md: "2xl" }}
-      isCentered
+      isCentered={{ base: false, md: true }}
+      scrollBehavior="inside"
     >
       <ModalOverlay bg="blackAlpha.700" />
       <ModalContent
         bg="gray.900"
         color="white"
-        mx={{ base: 2, md: 0 }}
-        height={{ base: "100vh", md: "78vh" }}
-        maxH={{ base: "100vh", md: "78vh" }}
+        mx={{ base: 0, md: 0 }}
+        my={{ base: 0, md: "auto" }}
+        height={{ base: "100dvh", md: "78vh" }}
+        maxH={{ base: "100dvh", md: "78vh" }}
+        borderRadius={{ base: 0, md: "md" }}
         display="flex"
         flexDirection="column"
         overflow="hidden"
+        pb={{ base: "env(safe-area-inset-bottom)", md: 0 }}
       >
-        <ModalHeader borderBottom="1px solid" borderColor="gray.700">
+        <ModalHeader
+          borderBottom="1px solid"
+          borderColor="gray.700"
+          pt={{ base: "calc(env(safe-area-inset-top) + 0.85rem)", md: 4 }}
+          pr={{ base: 14, md: 12 }}
+          pb={{ base: 3, md: 4 }}
+        >
           <Text fontSize="lg" fontWeight="bold">
             Ask Daniel&apos;s AI Assistant
           </Text>
@@ -167,26 +177,37 @@ export default function ChatModal({ isOpen, onClose }) {
           </Text>
         </ModalHeader>
 
-        <ModalCloseButton />
+        <ModalCloseButton
+          top={{ base: "calc(env(safe-area-inset-top) + 0.65rem)", md: 2 }}
+          right={{ base: 3, md: 3 }}
+          boxSize={{ base: 11, md: 8 }}
+          borderRadius="full"
+          bg={{ base: "whiteAlpha.200", md: "transparent" }}
+          _hover={{ bg: "whiteAlpha.300" }}
+          _active={{ bg: "whiteAlpha.400" }}
+        />
 
         <ModalBody
           display="flex"
           flexDirection="column"
-          pt={4}
+          pt={{ base: 3, md: 4 }}
           pb={2}
+          px={{ base: 3, md: 6 }}
           overflow="hidden"
           flex="1"
+          minH={0}
         >
           <Box
             flex="1"
             overflowY="auto"
-            mb={4}
-            pr={2}
+            mb={3}
+            pr={{ base: 1, md: 2 }}
             borderWidth="1px"
             borderColor="gray.700"
             borderRadius="lg"
-            p={3}
+            p={{ base: 2.5, md: 3 }}
             bg="gray.800"
+            minH={0}
           >
             <Stack spacing={3}>
               {messages.map((msg) => (
@@ -248,7 +269,7 @@ export default function ChatModal({ isOpen, onClose }) {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            rows={3}
+            rows={2}
             resize="none"
             bg="gray.800"
             borderColor="gray.700"
@@ -256,8 +277,16 @@ export default function ChatModal({ isOpen, onClose }) {
           />
         </ModalBody>
 
-        <ModalFooter borderTop="1px solid" borderColor="gray.700" gap={3}>
-          <Text fontSize="xs" color="gray.500" flex="1">
+        <ModalFooter
+          borderTop="1px solid"
+          borderColor="gray.700"
+          gap={{ base: 2, md: 3 }}
+          px={{ base: 3, md: 6 }}
+          py={{ base: 3, md: 4 }}
+          alignItems={{ base: "stretch", sm: "center" }}
+          flexDirection={{ base: "column", sm: "row" }}
+        >
+          <Text fontSize="xs" color="gray.500" flex="1" lineHeight="short">
             I can only talk about my professional background — not personal info.
           </Text>
           <Button
@@ -266,6 +295,7 @@ export default function ChatModal({ isOpen, onClose }) {
             isLoading={isLoading}
             loadingText="Sending"
             isDisabled={!input.trim()}
+            w={{ base: "100%", sm: "auto" }}
           >
             Send
           </Button>

--- a/src/components/ChatModal.test.jsx
+++ b/src/components/ChatModal.test.jsx
@@ -1,0 +1,59 @@
+import React from "react";
+import axios from "axios";
+import { describe, expect, it, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ChatModal from "./ChatModal.jsx";
+import { renderWithChakra } from "../test/renderWithChakra.jsx";
+
+vi.mock("axios");
+
+describe("ChatModal", () => {
+  it("renders the welcome prompt when open", () => {
+    renderWithChakra(<ChatModal isOpen onClose={vi.fn()} />);
+
+    expect(screen.getByText(/ask daniel's ai assistant/i)).toBeInTheDocument();
+    expect(screen.getByText(/ask me about my work experience/i)).toBeInTheDocument();
+  });
+
+  it("calls onClose from the close button", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    renderWithChakra(<ChatModal isOpen onClose={onClose} />);
+
+    await user.click(screen.getByRole("button", { name: /close/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends a message and renders the AI reply", async () => {
+    const user = userEvent.setup();
+    axios.post.mockResolvedValueOnce({
+      data: {
+        reply: "Daniel has deep DevSecOps and cloud delivery experience.",
+      },
+    });
+
+    renderWithChakra(<ChatModal isOpen onClose={vi.fn()} />);
+
+    await user.type(
+      screen.getByPlaceholderText(/ask me anything/i),
+      "What is Daniel good at?"
+    );
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        expect.stringMatching(/\/api\/ai\/chat$/),
+        expect.objectContaining({
+          message: "What is Daniel good at?",
+        })
+      );
+    });
+
+    expect(
+      await screen.findByText(/deep devsecops and cloud delivery experience/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -9,6 +9,7 @@ import {
   VStack
 } from "@chakra-ui/react";
 import { CheckCircleIcon } from "@chakra-ui/icons";
+import ScrollReveal from "./ScrollReveal.jsx";
 
 // Education and certifications data
 const education = [
@@ -43,13 +44,15 @@ export default function Education() {
       py={16}
       px={{ base: 4, md: 8 }}
     >
-      <Heading as="h2" size="xl" color="teal.300" textAlign="center" mb={8}>
-        Education & Certifications
-      </Heading>
+      <ScrollReveal>
+        <Heading as="h2" size="xl" color="teal.300" textAlign="center" mb={8}>
+          Education & Certifications
+        </Heading>
+      </ScrollReveal>
 
       <VStack spacing={12} maxW="4xl" mx="auto" align="stretch">
         {/* Education List */}
-        <Box>
+        <ScrollReveal direction="left">
           <Heading as="h3" size="lg" mb={4} color="gray.700">
             Education
           </Heading>
@@ -64,10 +67,10 @@ export default function Education() {
               </ListItem>
             ))}
           </List>
-        </Box>
+        </ScrollReveal>
 
         {/* Certifications List */}
-        <Box>
+        <ScrollReveal direction="right" delay={0.08}>
           <Heading as="h3" size="lg" mb={4} color="gray.700">
             Certifications
           </Heading>
@@ -81,7 +84,7 @@ export default function Education() {
               </ListItem>
             ))}
           </List>
-        </Box>
+        </ScrollReveal>
       </VStack>
     </Box>
   );

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -11,6 +11,7 @@ import {
   ListIcon
 } from "@chakra-ui/react";
 import { CheckCircleIcon } from "@chakra-ui/icons";
+import ScrollReveal from "./ScrollReveal.jsx";
 
 // Extracted from resume
 const experiences = [
@@ -93,29 +94,38 @@ export default function Experience() {
       py={16}
       px={{ base: 4, md: 8 }}
     >
-      <Heading as="h2" size="xl" color="teal.300" textAlign="center" mb={8}>
-        Experience
-      </Heading>
+      <ScrollReveal>
+        <Heading as="h2" size="xl" color="teal.300" textAlign="center" mb={8}>
+          Experience
+        </Heading>
+      </ScrollReveal>
 
       <VStack spacing={8} maxW="6xl" mx="auto" align="stretch">
         {experiences.map((exp, idx) => (
-          <Box key={idx} p={6} bg="gray.800" rounded="md" shadow="md">
-            <Stack direction={{ base: "column", md: "row" }} justify="space-between" align="flex-start">
-              <Box>
-                <Heading as="h3" size="md">{exp.title}</Heading>
-                <Text color="gray.400">{exp.company}</Text>
-              </Box>
-              <Badge colorScheme="teal" alignSelf="start">{exp.date}</Badge>
-            </Stack>
-            <List spacing={2} mt={4}>
-              {exp.bullets.map((b, i) => (
-                <ListItem key={i}>
-                  <ListIcon as={CheckCircleIcon} color="teal.300" />
-                  {b}
-                </ListItem>
-              ))}
-            </List>
-          </Box>
+          <ScrollReveal
+            key={exp.company}
+            delay={(idx % 3) * 0.05}
+            direction={idx % 2 === 0 ? "left" : "right"}
+            distance={28}
+          >
+            <Box p={6} bg="gray.800" rounded="md" shadow="md">
+              <Stack direction={{ base: "column", md: "row" }} justify="space-between" align="flex-start">
+                <Box>
+                  <Heading as="h3" size="md">{exp.title}</Heading>
+                  <Text color="gray.400">{exp.company}</Text>
+                </Box>
+                <Badge colorScheme="teal" alignSelf="start">{exp.date}</Badge>
+              </Stack>
+              <List spacing={2} mt={4}>
+                {exp.bullets.map((b, i) => (
+                  <ListItem key={i}>
+                    <ListIcon as={CheckCircleIcon} color="teal.300" />
+                    {b}
+                  </ListItem>
+                ))}
+              </List>
+            </Box>
+          </ScrollReveal>
         ))}
       </VStack>
     </Box>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,22 +1,25 @@
 import React from "react";
 import { Flex, Text } from "@chakra-ui/react";
+import ScrollReveal from "./ScrollReveal.jsx";
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
   return (
-    <Flex
-      as="footer"
-      w="100%"
-      bg="teal.600"
-      color="white"
-      py={4}
-      px={{ base: 4, md: 8 }}
-      justify="center"
-      align="center"
-    >
-      <Text fontSize="sm" textAlign="center">
-        © {currentYear} Daniel Saenz. All rights reserved.
-      </Text>
-    </Flex>
+    <ScrollReveal distance={18}>
+      <Flex
+        as="footer"
+        w="100%"
+        bg="teal.600"
+        color="white"
+        py={4}
+        px={{ base: 4, md: 8 }}
+        justify="center"
+        align="center"
+      >
+        <Text fontSize="sm" textAlign="center">
+          © {currentYear} Daniel Saenz. All rights reserved.
+        </Text>
+      </Flex>
+    </ScrollReveal>
   );
 }

--- a/src/components/Footer.test.jsx
+++ b/src/components/Footer.test.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+import Footer from "./Footer.jsx";
+import { renderWithChakra } from "../test/renderWithChakra.jsx";
+
+describe("Footer", () => {
+  it("renders the current year and owner", () => {
+    renderWithChakra(<Footer />);
+
+    expect(
+      screen.getByText(`${new Date().getFullYear()} Daniel Saenz. All rights reserved.`, {
+        exact: false,
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -14,6 +14,7 @@ import {
 } from "@chakra-ui/react";
 
 import portrait from "../assets/portrait.png";
+import ScrollReveal from "./ScrollReveal.jsx";
 
 export default function Hero({ onOpenChat }) {
   return (
@@ -31,10 +32,12 @@ export default function Hero({ onOpenChat }) {
       px={{ base: 4, md: 20 }}
     >
       {/* Text side */}
-      <Box
+      <ScrollReveal
         flex="1"
         textAlign={{ base: "center", md: "left" }}
         mt={{ base: 8, md: 0 }}
+        direction="left"
+        duration={0.8}
       >
         <Heading as="h1" size="2xl" mb={4}>
           Hi There,
@@ -112,10 +115,18 @@ export default function Hero({ onOpenChat }) {
             <Box>Deployed on AWS</Box>
           </Stack>
         </Show>
-      </Box>
+      </ScrollReveal>
 
       {/* Portrait */}
-      <Box flex="1" display="flex" justifyContent="center" mt={{ base: 20, md: 0 }}>
+      <ScrollReveal
+        flex="1"
+        display="flex"
+        justifyContent="center"
+        mt={{ base: 20, md: 0 }}
+        direction="right"
+        delay={0.12}
+        duration={0.8}
+      >
         <Image
           src={portrait}
           alt="Portrait"
@@ -126,7 +137,7 @@ export default function Hero({ onOpenChat }) {
           borderColor="teal.300"
           ml={{ base: 0, md: 16 }}
         />
-      </Box>
+      </ScrollReveal>
     </Flex>
   );
 }

--- a/src/components/MediaAndHighlights.jsx
+++ b/src/components/MediaAndHighlights.jsx
@@ -15,6 +15,7 @@ import {
   ModalCloseButton,
 } from "@chakra-ui/react";
 import { ArrowBackIcon, ArrowForwardIcon } from "@chakra-ui/icons";
+import ScrollReveal from "./ScrollReveal.jsx";
 
 const images = [
   {
@@ -74,19 +75,21 @@ export default function MediaAndHighlights() {
       py={16}
       px={{ base: 4, md: 8 }}
     >
-      <Heading
-        as="h2"
-        size="xl"
-        color="teal.300"
-        textAlign="center"
-        mb={8}
-      >
-        Media and Highlights
-      </Heading>
+      <ScrollReveal>
+        <Heading
+          as="h2"
+          size="xl"
+          color="teal.300"
+          textAlign="center"
+          mb={8}
+        >
+          Media and Highlights
+        </Heading>
+      </ScrollReveal>
 
       <VStack spacing={10} align="center" maxW="3xl" mx="auto">
         {/* --- Gallery Grid --- */}
-        <Box w="100%" maxW="800px">
+        <ScrollReveal w="100%" maxW="800px" distance={28}>
           <HStack spacing={2} justify="center" mb={2}>
             {totalPages > 1 && (
               <IconButton
@@ -167,7 +170,7 @@ export default function MediaAndHighlights() {
               Page {page + 1} of {totalPages}
             </Text>
           )}
-        </Box>
+        </ScrollReveal>
 
         {/* Lightbox Modal */}
         <Modal
@@ -272,43 +275,46 @@ export default function MediaAndHighlights() {
         </Modal>
 
         {/* ---- Interview Video ---- */}
-        <Box
-          w="100%"
-          maxW="640px"
-          aspectRatio={16 / 9}
-          borderRadius="lg"
-          overflow="hidden"
-          boxShadow="lg"
-        >
-          <iframe
-            width="100%"
-            height="100%"
-            src="https://www.youtube.com/embed/ljZLRukhIHQ?si=6DRklrtFUTFh_TzJ"
-            title="Daniel Saenz Interview"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-            style={{
-              display: "block",
-              width: "100%",
-              height: "100%",
-            }}
-          />
-        </Box>
+        <ScrollReveal w="100%" maxW="640px" delay={0.08} distance={28}>
+          <Box
+            w="100%"
+            aspectRatio={16 / 9}
+            borderRadius="lg"
+            overflow="hidden"
+            boxShadow="lg"
+          >
+            <iframe
+              width="100%"
+              height="100%"
+              src="https://www.youtube.com/embed/ljZLRukhIHQ?si=6DRklrtFUTFh_TzJ"
+              title="Daniel Saenz Interview"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              style={{
+                display: "block",
+                width: "100%",
+                height: "100%",
+              }}
+            />
+          </Box>
+        </ScrollReveal>
 
-        <Text
-          fontSize="md"
-          color="gray.200"
-          fontStyle="italic"
-          textAlign="center"
-          maxW="600px"
-        >
-          My interview on{" "}
-          <Text as="span" fontWeight="bold" color="teal.300">
-            “The Hackers&apos; Corner”
-          </Text>{" "}
-          at EPCC, where I share my DevOps journey, discuss cloud security, and
-          offer advice for those interested in tech careers.
-        </Text>
+        <ScrollReveal delay={0.12} distance={20}>
+          <Text
+            fontSize="md"
+            color="gray.200"
+            fontStyle="italic"
+            textAlign="center"
+            maxW="600px"
+          >
+            My interview on{" "}
+            <Text as="span" fontWeight="bold" color="teal.300">
+              “The Hackers&apos; Corner”
+            </Text>{" "}
+            at EPCC, where I share my DevOps journey, discuss cloud security, and
+            offer advice for those interested in tech careers.
+          </Text>
+        </ScrollReveal>
       </VStack>
     </Box>
   );

--- a/src/components/PortfolioSections.test.jsx
+++ b/src/components/PortfolioSections.test.jsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import About from "./About.jsx";
+import Education from "./Education.jsx";
+import Experience from "./Experience.jsx";
+import Hero from "./Hero.jsx";
+import MediaAndHighlights from "./MediaAndHighlights.jsx";
+import NavBar from "./NavBar.jsx";
+import Projects from "./Projects.jsx";
+import ScrollProgress from "./ScrollProgress.jsx";
+import Skills from "./Skills.jsx";
+import { renderWithChakra } from "../test/renderWithChakra.jsx";
+
+describe("portfolio sections", () => {
+  it("renders the hero and opens chat from the CTA", async () => {
+    const user = userEvent.setup();
+    const onOpenChat = vi.fn();
+
+    renderWithChakra(<Hero onOpenChat={onOpenChat} />);
+
+    expect(screen.getByRole("heading", { name: /hi there/i })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: /portrait/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /ask the ai/i }));
+
+    expect(onOpenChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the about, experience, education, and skills sections", () => {
+    renderWithChakra(
+      <>
+        <About />
+        <Experience />
+        <Education />
+        <Skills />
+      </>
+    );
+
+    expect(screen.getByRole("heading", { name: /about me/i })).toBeInTheDocument();
+    expect(screen.getByText(/software engineer & devsecops engineer/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /experience/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/senior devsecops engineer/i).length).toBeGreaterThan(0);
+    expect(screen.getByRole("heading", { name: /education & certifications/i })).toBeInTheDocument();
+    expect(screen.getByText(/aws certified cloud practitioner/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /skills/i })).toBeInTheDocument();
+    expect(screen.getByText("GitHub Actions")).toBeInTheDocument();
+  });
+
+  it("renders projects with the updated CD badge link", () => {
+    renderWithChakra(<Projects />);
+
+    expect(screen.getByRole("heading", { name: /projects/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /react portfolio/i })).toBeInTheDocument();
+    expect(screen.getByAltText(/react portfolio pipeline status/i)).toHaveAttribute(
+      "src",
+      expect.stringContaining("/actions/workflows/cd.yml/badge.svg")
+    );
+  });
+
+  it("opens and navigates the media lightbox", async () => {
+    const user = userEvent.setup();
+
+    renderWithChakra(<MediaAndHighlights />);
+
+    expect(screen.getByRole("heading", { name: /media and highlights/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /copilot workshop in arlington va/i }));
+
+    expect(screen.getByText(/july 25, 2024/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(screen.getByText(/gpt-enabled demo robot/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /prev/i }));
+
+    expect(screen.getByText(/hands-on copilot workshop/i)).toBeInTheDocument();
+  });
+
+  it("renders navigation and opens the mobile menu", async () => {
+    const user = userEvent.setup();
+
+    renderWithChakra(<NavBar />);
+
+    expect(screen.getByRole("link", { name: /daniel saenz/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /open menu/i }));
+
+    expect(screen.getByRole("button", { name: /close menu/i })).toBeInTheDocument();
+    expect(screen.getAllByRole("link", { name: /projects/i }).length).toBeGreaterThan(0);
+  });
+
+  it("renders the scroll progress indicator", () => {
+    const { container } = renderWithChakra(<ScrollProgress />);
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+});

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -16,6 +16,7 @@ import chakraImage from "../assets/chakra.png";
 import grantApiImage from "../assets/microservices.png";
 import reactImage from "../assets/react.png";
 import devsecopsImage from "../assets/devsecops.png";
+import ScrollReveal from "./ScrollReveal.jsx";
 
 const projects = [
   {
@@ -35,7 +36,7 @@ const projects = [
     repoLink: "https://github.com/disaenz/portfolio-site",
     img: chakraImage,
     pipelineBadge:
-      "https://github.com/disaenz/portfolio-site/actions/workflows/deploy.yml/badge.svg",
+      "https://github.com/disaenz/portfolio-site/actions/workflows/cd.yml/badge.svg",
     pipelineLink: "https://github.com/disaenz/portfolio-site/actions"
   },
   {
@@ -82,95 +83,99 @@ export default function Projects() {
       py={16}
       px={{ base: 4, md: 8 }}
     >
-      <Heading
-        as="h2"
-        size="xl"
-        color="teal.300"
-        textAlign="center"
-        mb={6}
-      >
-        Projects
-      </Heading>
+      <ScrollReveal>
+        <Heading
+          as="h2"
+          size="xl"
+          color="teal.300"
+          textAlign="center"
+          mb={6}
+        >
+          Projects
+        </Heading>
+      </ScrollReveal>
 
       <SimpleGrid
         columns={{ base: 1, md: 2, lg: 3 }}
         spacing={8}
         px={{ base: 0, md: 8 }}
       >
-        {projects.map((p) => (
-          <Box
-            key={p.title}
-            bg="white"
-            rounded="lg"
-            overflow="hidden"
-            shadow="md"
-            _hover={{ shadow: "lg" }}
-            transition="box-shadow 0.2s"
-          >
-            {/* Card image → repo */}
-            <Link href={p.repoLink} isExternal _hover={{ textDecoration: "none" }}>
-              <Image
-                src={p.img}
-                alt={p.title}
-                objectFit="cover"
-                h="200px"
-                w="100%"
-                cursor="pointer"
-              />
-            </Link>
+        {projects.map((p, index) => (
+          <ScrollReveal key={p.title} delay={(index % 3) * 0.06} distance={30}>
+            <Box
+              bg="white"
+              rounded="lg"
+              overflow="hidden"
+              shadow="md"
+              _hover={{ shadow: "lg", transform: "translateY(-4px)" }}
+              transition="box-shadow 0.2s, transform 0.2s"
+              h="100%"
+            >
+              {/* Card image → repo */}
+              <Link href={p.repoLink} isExternal _hover={{ textDecoration: "none" }}>
+                <Image
+                  src={p.img}
+                  alt={p.title}
+                  objectFit="cover"
+                  h="200px"
+                  w="100%"
+                  cursor="pointer"
+                />
+              </Link>
 
-            <Box pt={0} px={6} pb={6}>
-              <Heading as="h3" size="sm" mb={2} color="teal.600" mt={4}>
-                {p.title}
-              </Heading>
-              <Text mb={4} color="gray.600" fontSize={p.fontSize} fontWeight="medium">
-                {p.description}
-              </Text>
-            
-            {p.pipelineBadge && p.pipelineLink && (
-            <Link href={p.pipelineLink} isExternal>
-              <Image
-                src={p.pipelineBadge}
-                alt={`${p.title} pipeline status`}
-                h="20px"
-              />
-            </Link>
-          )}
-            <HStack mt={4} spacing={2} align="center">
-              {p.demoLink && (
+              <Box pt={0} px={6} pb={6}>
+                <Heading as="h3" size="sm" mb={2} color="teal.600" mt={4}>
+                  {p.title}
+                </Heading>
+                <Text mb={4} color="gray.600" fontSize={p.fontSize} fontWeight="medium">
+                  {p.description}
+                </Text>
+
+                {p.pipelineBadge && p.pipelineLink && (
+                  <Link href={p.pipelineLink} isExternal>
+                    <Image
+                      src={p.pipelineBadge}
+                      alt={`${p.title} pipeline status`}
+                      h="20px"
+                    />
+                  </Link>
+                )}
+                <HStack mt={4} spacing={2} align="center">
+                  {p.demoLink && (
+                    <Link
+                      href={p.demoLink}
+                      isExternal
+                      color="teal.500"
+                      fontWeight="bold"
+                      fontSize="sm"
+                    >
+                      View Demo
+                    </Link>
+                  )}
+                  {p.pipelineLink && (
+                  <Link
+                    href={p.pipelineLink}
+                    isExternal
+                    color="teal.500"
+                    fontWeight="bold"
+                    fontSize="sm"
+                  >
+                    View Pipeline
+                  </Link>
+                )}
                 <Link
-                  href={p.demoLink}
-                  isExternal
+                  href={p.repoLink}
                   color="teal.500"
                   fontWeight="bold"
                   fontSize="sm"
+                  isExternal
                 >
-                  View Demo
+                  Learn More
                 </Link>
-              )}
-              {p.pipelineLink && (
-              <Link
-                href={p.pipelineLink}
-                isExternal
-                color="teal.500"
-                fontWeight="bold"
-                fontSize="sm"
-              >
-                View Pipeline
-              </Link>
-            )}
-              <Link
-                href={p.repoLink}
-                color="teal.500"
-                fontWeight="bold"
-                fontSize="sm"
-                isExternal
-              >
-                Learn More
-              </Link>
-              </HStack>
+                </HStack>
+              </Box>
             </Box>
-          </Box>
+          </ScrollReveal>
         ))}
       </SimpleGrid>
     </Box>

--- a/src/components/ScrollProgress.jsx
+++ b/src/components/ScrollProgress.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Box, useToken } from "@chakra-ui/react";
+import { motion, useReducedMotion, useScroll, useSpring } from "framer-motion";
+
+export default function ScrollProgress() {
+  const { scrollYProgress } = useScroll();
+  const shouldReduceMotion = useReducedMotion();
+  const [teal300] = useToken("colors", ["teal.300"]);
+  const scaleX = useSpring(scrollYProgress, {
+    stiffness: 130,
+    damping: 24,
+    restDelta: 0.001,
+  });
+
+  return (
+    <Box
+      as={motion.div}
+      position="fixed"
+      top={0}
+      left={0}
+      right={0}
+      h="3px"
+      bg={teal300}
+      style={{
+        scaleX: shouldReduceMotion ? scrollYProgress : scaleX,
+        transformOrigin: "0%",
+      }}
+      zIndex={1400}
+      pointerEvents="none"
+      boxShadow={`0 0 18px ${teal300}`}
+    />
+  );
+}

--- a/src/components/ScrollReveal.jsx
+++ b/src/components/ScrollReveal.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  Box,
+  chakra,
+  shouldForwardProp,
+  useBreakpointValue,
+} from "@chakra-ui/react";
+import { isValidMotionProp, motion, useReducedMotion } from "framer-motion";
+
+const MotionBox = chakra(motion.div, {
+  shouldForwardProp: (prop) =>
+    isValidMotionProp(prop) || shouldForwardProp(prop),
+});
+
+export default function ScrollReveal({
+  children,
+  delay = 0,
+  distance = 32,
+  direction = "up",
+  duration = 0.65,
+  once = true,
+  ...props
+}) {
+  const shouldReduceMotion = useReducedMotion();
+  const isMobile = useBreakpointValue({ base: true, md: false });
+  const travel = isMobile ? Math.round(distance * 0.65) : distance;
+
+  if (shouldReduceMotion) {
+    return <Box {...props}>{children}</Box>;
+  }
+
+  const axisOffset =
+    direction === "left" || direction === "right"
+      ? {
+          x: direction === "left" ? -travel : travel,
+          y: 0,
+        }
+      : {
+          x: 0,
+          y: direction === "down" ? -travel : travel,
+        };
+
+  return (
+    <MotionBox
+      initial={{
+        opacity: 0,
+        filter: "blur(8px)",
+        ...axisOffset,
+      }}
+      whileInView={{
+        opacity: 1,
+        filter: "blur(0px)",
+        x: 0,
+        y: 0,
+      }}
+      viewport={{ once, amount: 0.18, margin: "0px 0px -8% 0px" }}
+      transition={{
+        duration,
+        delay,
+        ease: [0.22, 1, 0.36, 1],
+      }}
+      willChange="transform, opacity, filter"
+      {...props}
+    >
+      {children}
+    </MotionBox>
+  );
+}
+
+ScrollReveal.propTypes = {
+  children: PropTypes.node.isRequired,
+  delay: PropTypes.number,
+  distance: PropTypes.number,
+  direction: PropTypes.oneOf(["up", "down", "left", "right"]),
+  duration: PropTypes.number,
+  once: PropTypes.bool,
+};

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -7,6 +7,7 @@ import {
   Wrap,
   WrapItem,
 } from "@chakra-ui/react";
+import ScrollReveal from "./ScrollReveal.jsx";
 
 export default function Skills() {
   const skillCategories = [
@@ -41,6 +42,21 @@ export default function Skills() {
         "Trivy",
         "SonarQube",
         "GitOps",
+      ],
+    },
+    {
+      title: "Testing & Quality",
+      skills: [
+        "Vitest",
+        "React Testing Library",
+        "Jest",
+        "JSDOM",
+        "Pytest",
+        "unittest",
+        "JUnit",
+        "xUnit",
+        "ESLint",
+        "Coverage Reporting",
       ],
     },
     {
@@ -161,9 +177,11 @@ export default function Skills() {
       py={16}
       px={{ base: 4, md: 8 }}
     >
-      <Heading as="h2" size="xl" color="teal.300" textAlign="center" mb={8}>
-        Skills
-      </Heading>
+      <ScrollReveal>
+        <Heading as="h2" size="xl" color="teal.300" textAlign="center" mb={8}>
+          Skills
+        </Heading>
+      </ScrollReveal>
 
       <SimpleGrid
         columns={{ base: 1, md: 2 }}
@@ -171,22 +189,24 @@ export default function Skills() {
         maxW="6xl"
         mx="auto"
       >
-        {skillCategories.map((cat) => (
-          <Box key={cat.title}>
-            <Heading as="h3" size="md" mb={4} color="white">
-              {cat.title}
-            </Heading>
+        {skillCategories.map((cat, index) => (
+          <ScrollReveal key={cat.title} delay={(index % 4) * 0.04} distance={24}>
+            <Box>
+              <Heading as="h3" size="md" mb={4} color="white">
+                {cat.title}
+              </Heading>
 
-            <Wrap spacing={3}>
-              {cat.skills.map((skill) => (
-                <WrapItem key={skill}>
-                  <Tag size="md" variant="solid" colorScheme="teal">
-                    {skill}
-                  </Tag>
-                </WrapItem>
-              ))}
-            </Wrap>
-          </Box>
+              <Wrap spacing={3}>
+                {cat.skills.map((skill) => (
+                  <WrapItem key={skill}>
+                    <Tag size="md" variant="solid" colorScheme="teal">
+                      {skill}
+                    </Tag>
+                  </WrapItem>
+                ))}
+              </Wrap>
+            </Box>
+          </ScrollReveal>
         ))}
       </SimpleGrid>
     </Box>

--- a/src/test/renderWithChakra.jsx
+++ b/src/test/renderWithChakra.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { render } from "@testing-library/react";
+
+export function renderWithChakra(ui, options) {
+  return render(<ChakraProvider>{ui}</ChakraProvider>, options);
+}

--- a/src/test/setup.jsx
+++ b/src/test/setup.jsx
@@ -1,0 +1,80 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+/* eslint-disable react/prop-types */
+
+vi.mock("framer-motion", async () => {
+  const React = await import("react");
+  const createMotionComponent = (tag) => {
+    const MotionMock = React.forwardRef((props, ref) => {
+      const {
+        animate,
+        children,
+        exit,
+        initial,
+        transition,
+        viewport,
+        whileHover,
+        whileInView,
+        whileTap,
+        ...rest
+      } = props;
+
+      void animate;
+      void exit;
+      void initial;
+      void transition;
+      void viewport;
+      void whileHover;
+      void whileInView;
+      void whileTap;
+
+      return React.createElement(tag, { ref, ...rest }, children);
+    });
+
+    MotionMock.displayName = `MotionMock(${tag})`;
+
+    return MotionMock;
+  };
+
+  return {
+    isValidMotionProp: () => false,
+    motion: {
+      div: createMotionComponent("div"),
+    },
+    useReducedMotion: () => false,
+    useScroll: () => ({ scrollYProgress: 0 }),
+    useSpring: (value) => value,
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+globalThis.ResizeObserver = ResizeObserverMock;
+
+Element.prototype.scrollIntoView = vi.fn();
+window.scrollTo = vi.fn();

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,17 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/test/setup.jsx",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "json-summary"],
+      include: ["src/**/*.{js,jsx}"],
+      exclude: ["src/main.jsx", "src/test/**"],
+    },
+  },
 })


### PR DESCRIPTION
Here’s a PR description you can use:

```markdown
## Summary

This PR adds a broad polish pass across the portfolio experience and modernizes the CI/CD quality gates.

## Changes

- Added scroll-based reveal animations across portfolio sections using Framer Motion
- Added a subtle scroll progress indicator
- Improved the AI chat modal on mobile with better dynamic viewport sizing, safe-area spacing, and a larger close button
- Added a new `Testing & Quality` skills category
- Split GitHub Actions into separate CI and CD workflows:
  - `ci.yml` runs on PRs
  - `cd.yml` runs on pushes to `main`
- Updated CI to run `Lint` and `Unit Tests & Coverage` in parallel
- Added Vitest, React Testing Library, JSDOM, and V8 coverage
- Added initial component and interaction test coverage
- Added JUnit XML and coverage artifacts for GitHub Actions
- Added a Markdown coverage summary to the GitHub Actions job summary
- Updated README with new testing, coverage, CI/CD, animation, and AI assistant details
- Updated `.gitignore` for generated coverage and Vite/Turbo artifacts

## Validation

- `npm run lint`
- `npm run test:coverage`
- `npm run test:ci`
- `npm run coverage:summary`
- `npm run build`
- Validated `ci.yml` and `cd.yml` YAML parsing

## Notes

Current line coverage is approximately 76%. The remaining largest gaps are `App.jsx`, `theme.js`, and a few NavBar scroll edge cases, which can be improved in a future pass.
```